### PR TITLE
I exposed the user_identity and team_identity

### DIFF
--- a/lib/omniauth/strategies/slack.rb
+++ b/lib/omniauth/strategies/slack.rb
@@ -44,6 +44,8 @@ module OmniAuth
       extra do
         {
           raw_info: {
+            team_identity: team_identity,  # Requires identify:basic scope
+            user_identity: user_identity,  # Requires identify:basic scope
             user_info: user_info,         # Requires the users:read scope
             team_info: team_info,         # Requires the team:read scope
             web_hook_info: web_hook_info,


### PR DESCRIPTION
### What
I exposed the team_identity and user_identity

### Why
Because we need to use the scopes: `identity.basics,identity.team` and the gem doesn't expose it for us